### PR TITLE
Fix RSS feed parsing and remove debug log

### DIFF
--- a/news_fetcher.py
+++ b/news_fetcher.py
@@ -20,14 +20,12 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 DB_NAME = os.path.join(BASE_DIR, "news_articles.db")
 TABLE_NAME = "articles"
 
-logger.debug("BASE_DIR is: %s %s", BASE_DIR, DB_NAME)
-
 # --- Read Config ---
 CONFIG_PATH = os.path.join(BASE_DIR, "config.ini")
 
 config = configparser.ConfigParser()
 config.read(CONFIG_PATH)
-RSS_FEEDS = config['RSSFeeds']['feeds'].split(',')
+RSS_FEEDS = [url.strip() for url in config['RSSFeeds']['feeds'].split(',')]
 
 
 def initialize_db():


### PR DESCRIPTION
## Summary
- remove leftover debug output showing BASE_DIR
- trim whitespace from RSS feed URLs when reading config

## Testing
- `python -m py_compile db_manager.py main.py news_fetcher.py`

------
https://chatgpt.com/codex/tasks/task_e_684294f584ec83308f66dbe8732aa593