### PR TITLE
Refactor project structure

### DIFF
--- a/db_manager.py
+++ b/db_manager.py
@@ -5,15 +5,14 @@ A simple command-line tool to manage the database for AI News Bot.
 Provides commands to list entries, delete a specific entry by ID, or cleanup tables.
 """
 
-import sqlite3
 import argparse
 import logging
+import sqlite3
 import sys
-import os
+
+from settings import DB_PATH
 
 # --- Global Constants ---
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-DB_NAME = os.path.join(BASE_DIR, "news_articles.db")
 TABLE_ARTICLES = "articles"
 TABLE_POSTS = "posts"
 
@@ -26,72 +25,57 @@ def list_entries(table):
     """
     List all entries from the specified table.
     """
-    conn = sqlite3.connect(DB_NAME)
-    cursor = conn.cursor()
-
     try:
-        cursor.execute(f"SELECT * FROM {table}")
-        rows = cursor.fetchall()
-        if not rows:
-            logger.info("No entries found in table '%s'.", table)
-            return
-
-        # Print column headers based on table name
-        if table == TABLE_ARTICLES:
-            headers = ["ID", "Title", "Summary", "Link", "Published At", "MD5Sum"]
-        elif table == TABLE_POSTS:
-            headers = ["ID", "MD5Sum"]
-        else:
-            headers = []
-        
-        # Print header row
-        print(" | ".join(headers))
-        print("-" * 80)
-        for row in rows:
-            # Convert all items to string for uniform display
-            row_str = " | ".join(str(item) for item in row)
-            print(row_str)
+        with sqlite3.connect(DB_PATH) as conn:
+            cursor = conn.cursor()
+            cursor.execute(f"SELECT * FROM {table}")
+            rows = cursor.fetchall()
     except sqlite3.Error as e:
         logger.error("Error listing entries from %s: %s", table, e)
-    finally:
-        conn.close()
+        return
+
+    if not rows:
+        logger.info("No entries found in table '%s'.", table)
+        return
+
+    if table == TABLE_ARTICLES:
+        headers = ["ID", "Title", "Summary", "Link", "Published At", "MD5Sum"]
+    elif table == TABLE_POSTS:
+        headers = ["ID", "MD5Sum"]
+    else:
+        headers = []
+
+    print(" | ".join(headers))
+    print("-" * 80)
+    for row in rows:
+        row_str = " | ".join(str(item) for item in row)
+        print(row_str)
 
 
 def delete_entry(table, entry_id):
-    """
-    Delete a specific entry by ID from the specified table.
-    """
-    conn = sqlite3.connect(DB_NAME)
-    cursor = conn.cursor()
-
+    """Delete a specific entry by ID from the specified table."""
     try:
-        cursor.execute(f"DELETE FROM {table} WHERE id = ?", (entry_id,))
-        if cursor.rowcount == 0:
-            logger.info("No entry with ID %d found in table '%s'.", entry_id, table)
-        else:
-            conn.commit()
-            logger.info("Deleted entry with ID %d from table '%s'.", entry_id, table)
+        with sqlite3.connect(DB_PATH) as conn:
+            cursor = conn.cursor()
+            cursor.execute(f"DELETE FROM {table} WHERE id = ?", (entry_id,))
+            if cursor.rowcount == 0:
+                logger.info("No entry with ID %d found in table '%s'.", entry_id, table)
+            else:
+                conn.commit()
+                logger.info("Deleted entry with ID %d from table '%s'.", entry_id, table)
     except sqlite3.Error as e:
         logger.error("Error deleting entry from %s: %s", table, e)
-    finally:
-        conn.close()
 
 
 def cleanup_table(table):
-    """
-    Delete all entries from the specified table.
-    """
-    conn = sqlite3.connect(DB_NAME)
-    cursor = conn.cursor()
-
+    """Delete all entries from the specified table."""
     try:
-        cursor.execute(f"DELETE FROM {table}")
-        conn.commit()
-        logger.info("Cleaned up all entries from table '%s'.", table)
+        with sqlite3.connect(DB_PATH) as conn:
+            conn.execute(f"DELETE FROM {table}")
+            conn.commit()
+            logger.info("Cleaned up all entries from table '%s'.", table)
     except sqlite3.Error as e:
         logger.error("Error cleaning up table %s: %s", table, e)
-    finally:
-        conn.close()
 
 
 def main():

--- a/main.py
+++ b/main.py
@@ -4,12 +4,10 @@ main.py
 Responsible for generating social media posts for news articles and posting them to X/Twitter.
 """
 
-import configparser
 import hashlib
 import json
 import logging
 import re
-from dataclasses import dataclass
 from pathlib import Path
 from textwrap import dedent
 from typing import Optional, Tuple
@@ -17,48 +15,14 @@ from typing import Optional, Tuple
 import requests
 import sqlite3
 import tweepy
+from settings import DB_PATH, Config
 
 # Logging configuration
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
-# --- Paths ---
-BASE_DIR = Path(__file__).resolve().parent
-DB_PATH = BASE_DIR / "news_articles.db"
-CONFIG_PATH = BASE_DIR / "config.ini"
-
 # Regex to strip out <think>…</think>
 THINK_RE = re.compile(r"<think>.*?</think>", flags=re.DOTALL)
-
-
-@dataclass(frozen=True)
-class Config:
-    bearer_token: str
-    api_key: str
-    api_secret: str
-    access_token: str
-    access_token_secret: str
-    llm_api_url: str
-    model_name: str
-    debug_mode: bool
-
-    @classmethod
-    def load(cls, path: Path = CONFIG_PATH) -> "Config":
-        parser = configparser.ConfigParser(interpolation=None)
-        parser.read(path)
-        tw = parser["TwitterAPI"]
-        llm = parser["LLM"]
-        settings = parser["Settings"]
-        return cls(
-            bearer_token=tw["bearer_token"],
-            api_key=tw["api_key"],
-            api_secret=tw["api_secret"],
-            access_token=tw["access_token"],
-            access_token_secret=tw["access_token_secret"],
-            llm_api_url=llm["api_url"],
-            model_name=llm["model_name"],
-            debug_mode=settings.getboolean("debug_mode", fallback=False),
-        )
 
 
 def init_db(db_path: Path = DB_PATH) -> None:

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+from pathlib import Path
+import configparser
+
+BASE_DIR = Path(__file__).resolve().parent
+DB_PATH = BASE_DIR / "news_articles.db"
+CONFIG_PATH = BASE_DIR / "config.ini"
+
+
+@dataclass(frozen=True)
+class Config:
+    """Application configuration loaded from ``config.ini``."""
+
+    bearer_token: str
+    api_key: str
+    api_secret: str
+    access_token: str
+    access_token_secret: str
+    llm_api_url: str
+    model_name: str
+    debug_mode: bool
+
+    @classmethod
+    def load(cls, path: Path = CONFIG_PATH) -> "Config":
+        parser = configparser.ConfigParser(interpolation=None)
+        parser.read(path)
+        tw = parser["TwitterAPI"]
+        llm = parser["LLM"]
+        settings = parser["Settings"]
+        return cls(
+            bearer_token=tw["bearer_token"],
+            api_key=tw["api_key"],
+            api_secret=tw["api_secret"],
+            access_token=tw["access_token"],
+            access_token_secret=tw["access_token_secret"],
+            llm_api_url=llm["api_url"],
+            model_name=llm["model_name"],
+            debug_mode=settings.getboolean("debug_mode", fallback=False),
+        )

--- a/webapp.py
+++ b/webapp.py
@@ -1,9 +1,7 @@
-from pathlib import Path
 import sqlite3
 from flask import Flask, render_template_string
 
-BASE_DIR = Path(__file__).resolve().parent
-DB_PATH = BASE_DIR / "news_articles.db"
+from settings import DB_PATH
 
 app = Flask(__name__)
 


### PR DESCRIPTION
## Summary
- centralize configuration and paths in new `settings` module
- refactor DB utilities to use the shared constants
- modernize `news_fetcher` with context managers, lazy feed loading, and type hints
- clean up `db_manager` and `webapp` to use the new constants

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68459cf99a5c8330bd5b25ccda859434